### PR TITLE
View de victoire

### DIFF
--- a/app/controllers/game_sessions_controller.rb
+++ b/app/controllers/game_sessions_controller.rb
@@ -41,11 +41,14 @@ class GameSessionsController < ApplicationController
     # Condition de victoire : si le texte ne censure plus le titre, c'est gagné.
     if @htmlredact.include? @title
       flash[:notice] = "✨Bravo !✨"
+      redirect_to victory_game_session_path(@game_session)
     end
   end
 
-  def all
-    @all = game_session.all.where(guest_id)
+  def victory
+    @game_session = GameSession.find(params[:id])
+    @player = @game_session.guest
+
   end
 
 

--- a/app/views/game_sessions/victory.html.erb
+++ b/app/views/game_sessions/victory.html.erb
@@ -1,0 +1,6 @@
+Bravo !
+Vous avez trouvé la chanson en <%= @game_session.guesses.count %> coups.
+
+Vous avez fait <%= @player.game_sessions.count %> parties.
+
+Il s'agissait de <%= @game_session.songs[0].title %> par <%= @game_session.songs[0].author %>


### PR DESCRIPTION
Création très sommaire de la view "Victoire", à affiner

Dans la game_session, une redirection vers l'écran de victoire a lieu dès que le jeu est gagné.

L'écran de victoire montre le nombre de coups, le nombre de parties jouées et le nom et l'interpréte de la chanson.

